### PR TITLE
CloudWatchLogsへの書き込みできていないのを修正しました

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -107,6 +107,7 @@ resources:
           ManagedPolicyArns:
             # for invoke intent lambda
             - 'arn:aws:iam::aws:policy/service-role/AWSLambdaRole'
+            - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
           AssumeRolePolicyDocument:
             Version: '2012-10-17'
             Statement:


### PR DESCRIPTION
## PR内容
bugfixです。
実行はできますが、CloudWatchLogsへの書き込みができていなかったので修正しました。

## 変更点
* マネージドポリシーのAWSLambdaBasicExecutionRoleをintentSchema用のRoleにアタッチ