### PR TITLE
SlackのSlash Commandsのエンドポイントとして利用できるようにしました

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ yarn lint
 ※Setting up AWS-CLI configuration yet? see [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html)
 
 ## :information_source: Anything else
-<!-- show how to test, how to contribute -->
+After deploy, add SLACK_TOKEN to lambda environment variable.
 
 ## :pencil: Author
 [mesh1nek0x0](https://github.com/mesh1nek0x0)

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "sinon": "^5.0.10"
   },
   "dependencies": {
-    "aws-sdk": "^2.250.1"
+    "aws-sdk": "^2.250.1",
+    "query-string": "^6.1.0"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -69,7 +69,7 @@ functions:
     events:
       - http:
           path: greeting
-          method: get
+          method: post
 #      - s3: ${env:BUCKET}
 #      - schedule: rate(10 minutes)
 #      - sns: greeter-topic

--- a/src/__tests__/fixtures/hi-intent.json
+++ b/src/__tests__/fixtures/hi-intent.json
@@ -1,3 +1,3 @@
 {
-  "intent": "hi"
+  "body": "text=hi"
 }

--- a/src/greetingIntentSchema.js
+++ b/src/greetingIntentSchema.js
@@ -1,9 +1,20 @@
 'use strict';
 
 const AWS = require('aws-sdk');
+const querystring = require('query-string');
 
 module.exports.handler = async (event, context, callback) => {
     console.log('lambda will started');
+    const parameter = querystring.parse(event['body']);
+
+    if (parameter.token !== process.env.SLACK_TOKEN) {
+        return callback(null, {
+            statusCode: 400,
+            body: 'bad request',
+        });
+    }
+    const order = parameter.text.split(' ');
+    const intent = order.shift();
     const lambda = new AWS.Lambda();
     const params = {
         FunctionName: '',
@@ -12,13 +23,13 @@ module.exports.handler = async (event, context, callback) => {
         Payload: JSON.stringify({ hoge: 'hogera', bar: 'boo' }),
     };
     let acceptIntent = 'unkown';
-    if (event.intent === 'hi') {
+    if (intent === 'hi') {
         params.FunctionName = `skill-${process.env.STAGE}-intentHi`;
         acceptIntent = 'hi';
         console.log('hello!');
     }
 
-    if (event.intent === 'bye') {
+    if (intent === 'bye') {
         acceptIntent = 'bye';
         params.FunctionName = `skill-${process.env.STAGE}-intentBye`;
         console.log('good bye!');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2793,6 +2793,13 @@ qs@~6.5.1:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
+query-string@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.1.0.tgz#01e7d69f6a0940dac67a937d6c6325647aa4532a"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
@@ -3252,6 +3259,10 @@ static-extend@^0.1.1:
 stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## PR内容
#9 の対応です。
deployしたエンドポイントをSlackのSlash Commandsの
エンドポイントとして利用できるようにしました

![image](https://user-images.githubusercontent.com/10177370/41189512-06ec0e12-6c0a-11e8-8f79-57069f41a680.png)

## 変更点
* Slackからのパラメータを解析するように変更
* パラメータの受け取り方の変更に伴うテストの修正
* アクセス検証の400エラーのテストケース追加