### PR TITLE
Slack関連の操作を行う専用helperクラスを実装しました

### DIFF
--- a/src/__tests__/unit/lib/slackHelper_spec.js
+++ b/src/__tests__/unit/lib/slackHelper_spec.js
@@ -5,6 +5,7 @@ const slackHelper = require('../../../lib/slackHelper');
 describe('slackHelperのtest', () => {
     describe('正常系のテスト', () => {
         it('Slash Commandsのリクエストであればパースできること', () => {
+            // test時はSLACK_TOKENはundefinedなので送付しない
             const actual = slackHelper.parseSlashCommnadsRequestEvent({ body: 'text=hi hoge bar' });
             expect(actual.intent).toBe('hi');
             expect(actual.arg).toEqual(['hoge', 'bar']);
@@ -14,8 +15,14 @@ describe('slackHelperのtest', () => {
     describe('異常系のテスト', () => {
         it('Slash Commandsのリクエストでない場合、例外が返されること', () => {
             expect(() => {
-                slackHelper.parseSlashCommnadsRequestEvent({ body: 'sss' });
-            }).toThrowError('parse error');
+                slackHelper.parseSlashCommnadsRequestEvent({ token: null, body: 'sss' });
+            }).toThrowError("Cannot read property 'split' of undefined");
+        });
+
+        it('送付されたtokenが不正の場合、bad requestのエラーが返されること', () => {
+            expect(() => {
+                slackHelper.parseSlashCommnadsRequestEvent({ body: 'text=hi&token=invalid' });
+            }).toThrowError('bad request');
         });
     });
 });

--- a/src/__tests__/unit/lib/slackHelper_spec.js
+++ b/src/__tests__/unit/lib/slackHelper_spec.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const slackHelper = require('../../../lib/slackHelper');
+
+describe('slackHelperのtest', () => {
+    describe('正常系のテスト', () => {
+        it('Slash Commandsのリクエストであればパースできること', () => {
+            const actual = slackHelper.parseSlashCommnadsRequestEvent({ body: 'text=hi hoge bar' });
+            expect(actual.intent).toBe('hi');
+            expect(actual.arg).toEqual(['hoge', 'bar']);
+        });
+    });
+
+    describe('異常系のテスト', () => {
+        it('Slash Commandsのリクエストでない場合、例外が返されること', () => {
+            expect(() => {
+                slackHelper.parseSlashCommnadsRequestEvent({ body: 'sss' });
+            }).toThrowError('parse error');
+        });
+    });
+});

--- a/src/greetingIntentSchema.js
+++ b/src/greetingIntentSchema.js
@@ -6,10 +6,21 @@ const SlackHelper = require('./lib/slackHelper');
 module.exports.handler = async (event, context, callback) => {
     console.log('lambda will started');
 
-    let intent = 'unkonwn';
+    let intentLambdaName = '';
     try {
         const request = SlackHelper.parseSlashCommnadsRequestEvent(event);
-        intent = request.intent;
+        switch (request.intent) {
+            case 'hi':
+                intentLambdaName = `skill-${process.env.STAGE}-intentHi`;
+                console.log('hello!');
+                break;
+            case 'bye':
+                intentLambdaName = `skill-${process.env.STAGE}-intentBye`;
+                console.log('good bye!');
+                break;
+            default:
+                throw new Error('unkown intent');
+        }
     } catch (error) {
         return callback(null, {
             statusCode: 400,
@@ -19,21 +30,12 @@ module.exports.handler = async (event, context, callback) => {
 
     const lambda = new AWS.Lambda();
     const params = {
-        FunctionName: '',
+        FunctionName: intentLambdaName,
         ClientContext: 'greetingIntentSchema',
         InvocationType: 'Event',
         Payload: JSON.stringify({ hoge: 'hogera', bar: 'boo' }),
     };
 
-    if (intent === 'hi') {
-        params.FunctionName = `skill-${process.env.STAGE}-intentHi`;
-        console.log('hello!');
-    }
-
-    if (intent === 'bye') {
-        params.FunctionName = `skill-${process.env.STAGE}-intentBye`;
-        console.log('good bye!');
-    }
     await lambda
         .invoke(params)
         .promise()
@@ -42,7 +44,7 @@ module.exports.handler = async (event, context, callback) => {
                 statusCode: 200,
                 body: JSON.stringify({
                     message: 'Go Serverless v1.0! Your function executed successfully!',
-                    intent: intent,
+                    intent: intentLambdaName,
                 }),
             };
             console.log('lambda will be ended with success');

--- a/src/greetingIntentSchema.js
+++ b/src/greetingIntentSchema.js
@@ -1,20 +1,22 @@
 'use strict';
 
 const AWS = require('aws-sdk');
-const querystring = require('query-string');
+const SlackHelper = require('./lib/slackHelper');
 
 module.exports.handler = async (event, context, callback) => {
     console.log('lambda will started');
-    const parameter = querystring.parse(event['body']);
 
-    if (parameter.token !== process.env.SLACK_TOKEN) {
+    let intent = 'unkonwn';
+    try {
+        const request = SlackHelper.parseSlashCommnadsRequestEvent(event);
+        intent = request.intent;
+    } catch (error) {
         return callback(null, {
             statusCode: 400,
             body: 'bad request',
         });
     }
-    const order = parameter.text.split(' ');
-    const intent = order.shift();
+
     const lambda = new AWS.Lambda();
     const params = {
         FunctionName: '',
@@ -22,15 +24,13 @@ module.exports.handler = async (event, context, callback) => {
         InvocationType: 'Event',
         Payload: JSON.stringify({ hoge: 'hogera', bar: 'boo' }),
     };
-    let acceptIntent = 'unkown';
+
     if (intent === 'hi') {
         params.FunctionName = `skill-${process.env.STAGE}-intentHi`;
-        acceptIntent = 'hi';
         console.log('hello!');
     }
 
     if (intent === 'bye') {
-        acceptIntent = 'bye';
         params.FunctionName = `skill-${process.env.STAGE}-intentBye`;
         console.log('good bye!');
     }
@@ -42,7 +42,7 @@ module.exports.handler = async (event, context, callback) => {
                 statusCode: 200,
                 body: JSON.stringify({
                     message: 'Go Serverless v1.0! Your function executed successfully!',
-                    intent: acceptIntent,
+                    intent: intent,
                 }),
             };
             console.log('lambda will be ended with success');

--- a/src/lib/slackHelper.js
+++ b/src/lib/slackHelper.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const queryString = require('query-string');
+
+module.exports = class SlackHelper {
+    static parseSlashCommnadsRequestEvent(event) {
+        try {
+            const param = queryString.parse(event.body);
+            const order = param.text.split(' ');
+            return {
+                intent: order.shift(),
+                arg: order,
+            };
+        } catch (error) {
+            console.log(error);
+            throw new Error('parse error');
+        }
+    }
+};

--- a/src/lib/slackHelper.js
+++ b/src/lib/slackHelper.js
@@ -6,6 +6,9 @@ module.exports = class SlackHelper {
     static parseSlashCommnadsRequestEvent(event) {
         try {
             const param = queryString.parse(event.body);
+            if (param.token !== process.env.SLACK_TOKEN) {
+                throw new Error('bad request');
+            }
             const order = param.text.split(' ');
             return {
                 intent: order.shift(),
@@ -13,7 +16,7 @@ module.exports = class SlackHelper {
             };
         } catch (error) {
             console.log(error);
-            throw new Error('parse error');
+            throw new Error(error.message);
         }
     }
 };


### PR DESCRIPTION
## PR内容
#12 の対応です。
とりいそぎ、Slackからのrequestの検証とrequestパラメータの解析を移譲しました。

## 変更点
* ceb875e パラメータをパースをSlackHelperクラスとして実装
* 55fddde request validationをSlackHelperにも実装
* bd75ffe SlackHelperをindexに適用
* 0b1dbf0 intentの判定をvalidationに含めた