### PR TITLE
intentSchemaからintentへSlash Commandsの引数を引き継げるようにしました

### DIFF
--- a/src/__tests__/unit/greetingIntentSchema_spec.js
+++ b/src/__tests__/unit/greetingIntentSchema_spec.js
@@ -37,6 +37,20 @@ describe('greetingIntentSchemaのテスト', () => {
                 expect(body.intent).toBe(testCase.expect);
             });
         });
+
+        it('受け取ったコマンドの引数をintentに引き継げること', async () => {
+            AWS.mock('Lambda', 'invoke', (param, callback) => {
+                // spyの仕込み方が不明
+                expect(param).toEqual({
+                    ClientContext: 'greetingIntentSchema',
+                    FunctionName: `skill-${process.env.STAGE}-intentHi`,
+                    InvocationType: 'Event',
+                    Payload: JSON.stringify({ args: ['arg1', 'arg2'] }),
+                });
+                callback(null, 'lambda invoke success');
+            });
+            await intentSchema.handler({ body: 'text=hi%20arg1%20arg2' }, {}, () => {});
+        });
     });
 
     describe('異常系', () => {

--- a/src/greetingIntentSchema.js
+++ b/src/greetingIntentSchema.js
@@ -7,8 +7,10 @@ module.exports.handler = async (event, context, callback) => {
     console.log('lambda will started');
 
     let intentLambdaName = '';
+    let intentArgs;
     try {
         const request = SlackHelper.parseSlashCommnadsRequestEvent(event);
+        intentArgs = request.arg;
         switch (request.intent) {
             case 'hi':
                 intentLambdaName = `skill-${process.env.STAGE}-intentHi`;
@@ -33,7 +35,7 @@ module.exports.handler = async (event, context, callback) => {
         FunctionName: intentLambdaName,
         ClientContext: 'greetingIntentSchema',
         InvocationType: 'Event',
-        Payload: JSON.stringify({ hoge: 'hogera', bar: 'boo' }),
+        Payload: JSON.stringify({ args: intentArgs }),
     };
 
     await lambda


### PR DESCRIPTION
## PR内容
掲題の通りです。
Slash Commandsで渡した引数をintentにも引き継げるようになりました

## 変更点
* argsとしてintentを呼び出すようにintentSchemaを変更
* パラメータが意図通り渡せているかテストを追加

#18 のために必要な修正です