### PR TITLE
intentへSlack通知のURLを引き継げるようにしました

### DIFF
--- a/src/__tests__/unit/greetingIntentSchema_spec.js
+++ b/src/__tests__/unit/greetingIntentSchema_spec.js
@@ -49,7 +49,21 @@ describe('greetingIntentSchemaのテスト', () => {
                 });
                 callback(null, 'lambda invoke success');
             });
-            await intentSchema.handler({ body: 'text=hi%20arg1%20arg2' }, {}, () => {});
+            await intentSchema.handler({ body: 'text=hi arg1 arg2' }, {}, () => {});
+        });
+
+        it('受け取ったresponse_urlをintentに引き継げること', async () => {
+            AWS.mock('Lambda', 'invoke', (param, callback) => {
+                // spyの仕込み方が不明
+                expect(param).toEqual({
+                    ClientContext: 'greetingIntentSchema',
+                    FunctionName: `skill-${process.env.STAGE}-intentHi`,
+                    InvocationType: 'Event',
+                    Payload: JSON.stringify({ args: [], responseUrl: 'https' }),
+                });
+                callback(null, 'lambda invoke success');
+            });
+            await intentSchema.handler({ body: 'text=hi&response_url=https' }, {}, () => {});
         });
     });
 

--- a/src/__tests__/unit/lib/slackHelper_spec.js
+++ b/src/__tests__/unit/lib/slackHelper_spec.js
@@ -6,9 +6,12 @@ describe('slackHelperのtest', () => {
     describe('正常系のテスト', () => {
         it('Slash Commandsのリクエストであればパースできること', () => {
             // test時はSLACK_TOKENはundefinedなので送付しない
-            const actual = slackHelper.parseSlashCommnadsRequestEvent({ body: 'text=hi hoge bar' });
-            expect(actual.intent).toBe('hi');
-            expect(actual.arg).toEqual(['hoge', 'bar']);
+            const actual = slackHelper.parseSlashCommnadsRequestEvent({ body: 'text=hi hoge bar&response_url=http' });
+            expect(actual).toEqual({
+                intent: 'hi',
+                arg: ['hoge', 'bar'],
+                responseUrl: 'http',
+            });
         });
     });
 

--- a/src/greetingIntentSchema.js
+++ b/src/greetingIntentSchema.js
@@ -8,9 +8,11 @@ module.exports.handler = async (event, context, callback) => {
 
     let intentLambdaName = '';
     let intentArgs;
+    let responseUrl = '';
     try {
         const request = SlackHelper.parseSlashCommnadsRequestEvent(event);
         intentArgs = request.arg;
+        responseUrl = request.responseUrl;
         switch (request.intent) {
             case 'hi':
                 intentLambdaName = `skill-${process.env.STAGE}-intentHi`;
@@ -35,8 +37,12 @@ module.exports.handler = async (event, context, callback) => {
         FunctionName: intentLambdaName,
         ClientContext: 'greetingIntentSchema',
         InvocationType: 'Event',
-        Payload: JSON.stringify({ args: intentArgs }),
+        Payload: JSON.stringify({
+            args: intentArgs,
+            responseUrl: responseUrl,
+        }),
     };
+    console.log('param:', params);
 
     await lambda
         .invoke(params)

--- a/src/greetingIntentSchema.js
+++ b/src/greetingIntentSchema.js
@@ -42,7 +42,6 @@ module.exports.handler = async (event, context, callback) => {
             responseUrl: responseUrl,
         }),
     };
-    console.log('param:', params);
 
     await lambda
         .invoke(params)

--- a/src/lib/slackHelper.js
+++ b/src/lib/slackHelper.js
@@ -13,6 +13,7 @@ module.exports = class SlackHelper {
             return {
                 intent: order.shift(),
                 arg: order,
+                responseUrl: param.response_url,
             };
         } catch (error) {
             console.log(error);


### PR DESCRIPTION
## PR内容
掲題の通りです。
Slash Commandsに含まれるresponse用のURLをintentに引き継げるようにしました。

## 変更点
* SlackHelperで受け取ったresponse_urlをresponseUrlとしてパースできるように改修
* intent呼び出し時にresponseUrlをパラメータに追加＆そのテストを追加