### PR TITLE
Slackへのmessage postが失敗する場合のテストを追加しました

### DIFF
--- a/src/__tests__/unit/lib/slackHelper_spec.js
+++ b/src/__tests__/unit/lib/slackHelper_spec.js
@@ -42,5 +42,21 @@ describe('slackHelperのtest', () => {
                 slackHelper.parseSlashCommnadsRequestEvent({ body: 'text=hi&token=invalid' });
             }).toThrowError('bad request');
         });
+
+        it('Slackへのメッセージ送信に失敗した場合、例外が返されること', async () => {
+            // 実際には通信しないようにする
+            sinon.stub(IncomingWebhook.prototype, 'send').callsFake(() => {
+                throw new Error('slack api error with stub');
+            });
+
+            // see: jest await async sample
+            // https://facebook.github.io/jest/docs/en/tutorial-async.html
+            expect.assertions(1);
+            try {
+                await slackHelper.postMessage('slack helper', 'https://hooks.slack.com/services/xxxx');
+            } catch (error) {
+                expect(error.message).toBe('post message failed');
+            }
+        });
     });
 });


### PR DESCRIPTION
## PR内容
Slackへのメッセージpostが失敗する際のテストケースを追加しました

#26 の対応です。

これでカバレッジがサイコーな状態です。
![image](https://user-images.githubusercontent.com/10177370/41690838-658b4c36-7532-11e8-982b-e2f57b24d388.png)

## 変更点
* Jestのサンプル通りにAsync/Awaitの例外テストを追加