### PR TITLE
intentから実行元のSlack channelへ通知できるようにしました

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "invoke": "sls invoke local -f greeting --path src/__tests__/fixtures/hi-intent.json",
-    "invoke:intent-hi": "sls invoke local -f hiIntent",
+    "invoke:intent-hi": "sls invoke local -f intentHi",
     "deploy": "sls deploy",
     "lint": "eslint src",
     "test": "jest --config=jest.config.json"

--- a/src/__tests__/unit/intentHi_spec.js
+++ b/src/__tests__/unit/intentHi_spec.js
@@ -2,15 +2,36 @@
 
 const sinon = require('sinon');
 const intent = require('../../intentHi');
+const SlackHelper = require('../../lib/slackHelper');
 
 describe('intentHiのテスト', () => {
+    beforeEach(() => {
+        sinon.restore();
+    });
+
     describe('正常系のテスト', () => {
         it('正常終了すること', async () => {
             const callback = sinon.stub();
+            sinon.stub(SlackHelper, 'postMessage').callsFake(() => {
+                return Promise.resolve('success with stub');
+            });
             await intent.handler({}, {}, callback);
             expect(callback.callCount).toBe(1);
             expect(callback.args[0][0]).toBeNull();
             expect(callback.args[0][1]).toBe('end with successfully');
+        });
+    });
+
+    describe('異常系のテスト', () => {
+        it('Slackへの通知が失敗してもLambdaは正常終了すること', async () => {
+            const callback = sinon.stub();
+            sinon.stub(SlackHelper, 'postMessage').callsFake(() => {
+                return Promise.reject('failure with stub');
+            });
+            await intent.handler({}, {}, callback);
+            expect(callback.callCount).toBe(1);
+            expect(callback.args[0][0]).toBeNull();
+            expect(callback.args[0][1]).toBe('end with failure');
         });
     });
 });

--- a/src/intentHi.js
+++ b/src/intentHi.js
@@ -1,9 +1,17 @@
 'use strict';
+const SlackHelper = require('./lib/slackHelper');
 
 module.exports.handler = async (event, context, callback) => {
     console.log('intent hi will be started');
 
     // implement your code
-    callback(null, 'end with successfully');
+    try {
+        await SlackHelper.postMessage('hi intent response', event.responseUrl);
+    } catch (error) {
+        console.log(error);
+        // lambdaが再実行はしないように成功扱いで終了する
+        return callback(null, 'end with failure');
+    }
     console.log('intent hi will be ended');
+    callback(null, 'end with successfully');
 };


### PR DESCRIPTION
## PR内容
#21 の対応です。
main処理であるintentの実行が済んだら、Slackへ通知できるようにしました。

![image](https://user-images.githubusercontent.com/10177370/41779956-53221da8-766e-11e8-89f7-cc2bd1072c45.png)

## 変更点
* #25 をintentのLambdaから呼び出す形に変更
* 上記に伴い、intentのテストケースを修正